### PR TITLE
Build a C-compatible shared library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,9 @@ harness = false
 
 [profile.release]
 strip = true
+
+[build-dependencies]
+cbindgen = "0.27.0"
+
+[lib]
+crate-type = ["lib", "cdylib"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Primarily changes the `CRC-64/XZ` (aka `CRC-64/GO-ECMA`) polynomial from [crc64f
 
 ## Usage
 
+### Rust
+
 ```rust
 use crc64fast_nvme::Digest;
 
@@ -31,6 +33,11 @@ c.write(b"world!");
 let checksum = c.sum64();
 assert_eq!(checksum, 0xd9160d1fa8e418e3);
 ```
+
+### C-compatible shared library
+`cargo build` will produce a shared library target (`.so` on Linux, `.dll` on Windows, `.dylib` on macOS, etc) and `crc64vnme.h` header file for use in non-Rust projects, such as through FFI.
+
+There is a [crc-fast-php](https://github.com/awesomized/crc-fast-php) library using it with PHP, for example.
 
 ## CLI example
 A simple CLI implementation can be found in [crc_64_nvme_checksum.rs](src\bin\crc_64_nvme_checksum.rs), which will calculate the `CRC-64/NVME` checksum for a file on disk.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+// build.rs
+
+extern crate cbindgen;
+
+fn main() {
+    let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    cbindgen::generate(crate_dir)
+        .expect("Unable to generate C bindings.")
+        .write_to_file("crc64nvme.h");
+}

--- a/crc64nvme.h
+++ b/crc64nvme.h
@@ -1,0 +1,36 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+/// Represents an in-progress CRC-64 computation.
+struct Digest;
+
+/// Begin functionality for building a C-compatible library
+///
+/// Opaque type for C for use in FFI
+struct DigestHandle {
+  Digest *_0;
+};
+
+extern "C" {
+
+DigestHandle *digest_new();
+
+/// # Safety
+///
+/// Uses unsafe method calls
+void digest_write(DigestHandle *handle, const char *data, uintptr_t len);
+
+/// # Safety
+///
+/// Uses unsafe method calls
+uint64_t digest_sum64(const DigestHandle *handle);
+
+/// # Safety
+///
+/// Uses unsafe method calls
+void digest_free(DigestHandle *handle);
+
+}  // extern "C"


### PR DESCRIPTION
Adds support for building and using this Rust library with other software via a C-compatible shared library.

For example, here's a [crc-fast-php](https://github.com/awesomized/crc-fast-php?) library using it.