### PR TITLE
Add new `c-bindings` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ rand = "0.8"
 pmull = [] # deprecated, no longer have any effect.
 vpclmulqdq = ["lazy_static"]
 fake-simd = []
+c-bindings = []
 
 [[bench]]
 name = 'benchmark'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8"
 pmull = [] # deprecated, no longer have any effect.
 vpclmulqdq = ["lazy_static"]
 fake-simd = []
-c-bindings = []
+c-bindings = ["dep:cbindgen"]
 
 [[bench]]
 name = 'benchmark'
@@ -38,7 +38,7 @@ harness = false
 strip = true
 
 [build-dependencies]
-cbindgen = "0.27.0"
+cbindgen = {version = "0.27.0", optional = true}
 
 [lib]
 name = "crc64fast_nvme"

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,13 @@
 // build.rs
 
-extern crate cbindgen;
-
 fn main() {
-    let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    #[cfg(feature = "c-bindings")]
+    {
+        extern crate cbindgen;
+        let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    cbindgen::generate(crate_dir)
-        .expect("Unable to generate C bindings.")
-        .write_to_file("crc64fast_nvme.h");
+        cbindgen::generate(crate_dir)
+            .expect("Unable to generate C bindings.")
+            .write_to_file("crc64fast_nvme.h");
+    }
 }


### PR DESCRIPTION
The c bindings generated in `build.rs` were causing issues for some sandboxed builds. This PR introduces a new feature flag `c-bindings` that allows building those bindings to be opted in to. It is off by default. This would technically be a breaking change for anyone using the c bindings, so we could instead make it a default feature that can be disabled if that is a worry. 